### PR TITLE
feat: add durable backing to the queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 checkpoint.ndjson
+checkpoint.jsonl
+.offset

--- a/src/models/dawarich.rs
+++ b/src/models/dawarich.rs
@@ -1,7 +1,9 @@
 use log::{debug, error, info};
-use std::{cmp, env};
+use std::{cmp, env, path::PathBuf};
 
 use crate::models::{owntracks::OwntracksPayload, persistent_queue::PersistentQueue};
+
+const CONSECUTIVE_SUCCESSES_FOR_HEALTH: u16 = 3;
 
 #[derive(Debug, Clone)]
 enum ApiStatus {
@@ -32,7 +34,9 @@ impl Dawarich {
             "http://{}:{}/api/v1/owntracks/points",
             dawarich_base_url, dawarich_port
         );
-        let filepath = env::var("EVENT_LOG").unwrap_or_else(|_| "checkpoint.ndjson".to_string());
+        let filepath =
+            PathBuf::from(env::var("EVENT_LOG").unwrap_or_else(|_| "checkpoint".to_string()))
+                .with_extension("jsonl");
 
         info!(
             "Sending data to Dawarich at {}:{}",
@@ -55,25 +59,29 @@ impl Dawarich {
             .post(&self.endpoint)
             .json(&payload)
             .bearer_auth(&self.api_key)
-            .send();
+            .send()
+            .and_then(|r| r.error_for_status());
 
         match response {
             Ok(resp) => {
                 debug!("Response: {resp:?}");
-                self.concurrent_successes = cmp::min(self.concurrent_successes + 1, u16::MAX - 1);
-                debug_assert!(self.concurrent_successes <= 3);
+                self.concurrent_successes = cmp::min(
+                    self.concurrent_successes + 1,
+                    CONSECUTIVE_SUCCESSES_FOR_HEALTH,
+                );
+                debug_assert!(self.concurrent_successes <= CONSECUTIVE_SUCCESSES_FOR_HEALTH);
 
-                if self.concurrent_successes >= 3 {
+                if self.concurrent_successes >= CONSECUTIVE_SUCCESSES_FOR_HEALTH {
                     self.status = ApiStatus::Healthy;
                 }
+
+                self.queue.commit_pop();
             }
             Err(err) => {
-                error!("Request failed with error: {err:?}");
+                error!("request failed with error {err:?}");
                 self.concurrent_successes = 0;
-                debug!("Setting status to degraded");
+                debug!("setting status to degraded");
                 self.status = ApiStatus::Degraded;
-
-                self.queue.push(payload);
             }
         }
     }

--- a/src/models/persistent_queue.rs
+++ b/src/models/persistent_queue.rs
@@ -6,6 +6,8 @@ use std::{collections::VecDeque, fs::OpenOptions};
 
 use crate::models::owntracks::OwntracksPayload;
 
+const FILE_COMPACT_LINE_THRESHOLD: u16 = 50;
+
 #[derive(Debug, Clone)]
 pub struct PersistentQueue {
     pub filepath: PathBuf,
@@ -32,8 +34,7 @@ impl PersistentQueue {
     }
 
     pub fn push(&mut self, payload: OwntracksPayload) {
-        self.append(&payload);
-        self.queue.push_back(payload);
+        self.append(payload);
         debug!("current queue size: {}", self.queue.len());
     }
 
@@ -47,8 +48,7 @@ impl PersistentQueue {
         self.line_offset += 1;
         debug!("commiting offset {}", self.line_offset);
         self.write_offset();
-        // compact
-        if self.line_offset > 50 {
+        if self.line_offset >= FILE_COMPACT_LINE_THRESHOLD {
             self.compact();
         }
     }
@@ -72,7 +72,7 @@ impl PersistentQueue {
         }
     }
 
-    fn append(&self, payload: &OwntracksPayload) {
+    fn append(&mut self, payload: OwntracksPayload) {
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
@@ -86,6 +86,7 @@ impl PersistentQueue {
         } else {
             error!("failed to deserialize payload: {payload:?}")
         }
+        self.queue.push_back(payload);
     }
 
     fn commit(&mut self) {

--- a/src/models/persistent_queue.rs
+++ b/src/models/persistent_queue.rs
@@ -1,40 +1,75 @@
 use log::{debug, error, info};
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 use std::{collections::VecDeque, fs::OpenOptions};
 
 use crate::models::owntracks::OwntracksPayload;
 
 #[derive(Debug, Clone)]
 pub struct PersistentQueue {
-    pub filepath: String,
+    pub filepath: PathBuf,
     pub queue: VecDeque<OwntracksPayload>,
+    line_offset: u16,
 }
 
 impl PersistentQueue {
-    pub fn new(filepath: String) -> Self {
-        let data = load_wal(&filepath);
+    pub fn new(filepath: PathBuf) -> Self {
+        let offset_path = match filepath.parent() {
+            Some(parent) => parent.join(".offset"),
+            None => PathBuf::from("."),
+        };
+        debug!("setting offset path in {:?}", offset_path);
+        let offset = load_offset(offset_path);
+
+        let data = load_wal(&filepath, offset);
 
         Self {
             filepath,
             queue: data,
+            line_offset: offset,
         }
     }
 
     pub fn push(&mut self, payload: OwntracksPayload) {
         self.append(&payload);
         self.queue.push_back(payload);
-        debug!("Queue size {}", self.queue.len());
+        debug!("current queue size: {}", self.queue.len());
     }
 
-    pub fn pop(&mut self) -> Option<OwntracksPayload> {
-        let payload = self.queue.pop_front();
-        self.save();
-        payload
+    // Peek the front to try push
+    pub fn pop(&self) -> Option<OwntracksPayload> {
+        self.queue.front().cloned()
     }
 
-    pub fn is_empty(&mut self) -> bool {
-        self.queue.len() == 0
+    pub fn commit_pop(&mut self) {
+        let _ = self.queue.pop_front();
+        self.line_offset += 1;
+        debug!("commiting offset {}", self.line_offset);
+        self.write_offset();
+        // compact
+        if self.line_offset > 50 {
+            self.compact();
+        }
+    }
+
+    fn compact(&mut self) {
+        self.commit();
+        self.line_offset = 0;
+        self.write_offset();
+    }
+
+    fn write_offset(&mut self) {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(".offset")
+            .expect("This should open!");
+
+        if let Err(e) = writeln!(file, "{}", self.line_offset) {
+            error!("couldn't write to file {}", e);
+        }
     }
 
     fn append(&self, payload: &OwntracksPayload) {
@@ -53,12 +88,13 @@ impl PersistentQueue {
         }
     }
 
-    fn save(&self) {
-        let mut file = OpenOptions::new()
+    fn commit(&mut self) {
+        let tmp_filepath = self.filepath.with_extension("jsonl.tmp");
+        let mut tmp_file = OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
-            .open(&self.filepath)
+            .open(&tmp_filepath)
             .expect("This should open!");
 
         for payload in &self.queue {
@@ -66,27 +102,31 @@ impl PersistentQueue {
 
             match result {
                 Ok(deserialized) => {
-                    if let Err(e) = writeln!(file, "{deserialized}") {
+                    if let Err(e) = writeln!(tmp_file, "{deserialized}") {
                         error!("couldn't write to file {}", e);
                     }
                 }
                 Err(_) => error!("failed to deserialize payload: {payload:?}"),
             }
         }
+
+        debug!("swapping {:?} to main {:?}", &tmp_filepath, &self.filepath);
+        fs::rename(&tmp_filepath, &self.filepath).expect("to work");
     }
 }
 
-pub fn load_wal(wal_path: &String) -> VecDeque<OwntracksPayload> {
+fn load_wal(wal_path: &Path, offset: u16) -> VecDeque<OwntracksPayload> {
     let file = fs::File::open(wal_path);
 
     let mut payloads = VecDeque::new();
 
     match file {
         Ok(c) => {
-            info!("Loading WAL to memory from {wal_path}");
+            info!("loading WAL to memory from {wal_path:?}");
             let reader = BufReader::new(c);
 
-            for line in reader.lines() {
+            debug!("reading from line {offset}");
+            for line in reader.lines().skip(offset.into()) {
                 match line {
                     Ok(payload) => {
                         match serde_json::from_str::<OwntracksPayload>(&payload) {
@@ -102,9 +142,10 @@ pub fn load_wal(wal_path: &String) -> VecDeque<OwntracksPayload> {
                 }
             }
 
+            debug!("payloads loaded from disk: {}", payloads.len());
+
             payloads
         }
-        // TODO: Should handle all errors
         Err(err) => match err.kind() {
             std::io::ErrorKind::NotFound => {
                 info!("no existing WAL found");
@@ -115,4 +156,26 @@ pub fn load_wal(wal_path: &String) -> VecDeque<OwntracksPayload> {
             }
         },
     }
+}
+
+fn load_offset(offset_path: PathBuf) -> u16 {
+    let content = match std::fs::read_to_string(offset_path) {
+        Ok(content) => content,
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => {
+                info!("no existing offset found");
+                return 0;
+            }
+            _ => {
+                error!("unexpected error: {err}");
+                return 0;
+            }
+        },
+    };
+
+    content
+        .lines()
+        .next()
+        .and_then(|x| x.trim().parse().ok())
+        .unwrap_or(0)
 }


### PR DESCRIPTION
Create a new .offset file to track where we are in the queue in case of crash.
We no longer pop_front naively and we "peek" first then if successfully commit the pop alongside incrementing the offset line. Beyond a certain line limit we compact and save what we haven't already successfully pushed

When committing, we write to a tmp file before doing an atomic swap so we aren't left with a half written file

Will need to add some good testing in this as well